### PR TITLE
Fixes camera movement trembling

### DIFF
--- a/src/main/java/net/sknv/engine/GameEngine.java
+++ b/src/main/java/net/sknv/engine/GameEngine.java
@@ -35,7 +35,7 @@ public class GameEngine implements Runnable {
         window.init();
         timer.init();
         mouseInput.init(window);
-        gameLogic.init(window);
+        gameLogic.init(window, mouseInput);
     }
 
     protected void gameLoop() {

--- a/src/main/java/net/sknv/engine/IGameLogic.java
+++ b/src/main/java/net/sknv/engine/IGameLogic.java
@@ -2,7 +2,7 @@ package net.sknv.engine;
 
 public interface IGameLogic {
 
-    void init(Window window) throws Exception;
+    void init(Window window, MouseInput mouseInput) throws Exception;
     void input(Window window, MouseInput mouseInput);
     void update(Window window, MouseInput mouseInput, float interval);
     void render(Window window, MouseInput mouseInput);

--- a/src/main/java/net/sknv/engine/MouseInput.java
+++ b/src/main/java/net/sknv/engine/MouseInput.java
@@ -46,8 +46,7 @@ public class MouseInput {
     public void input(Window window) {
         displVec.x = 0;
         displVec.y = 0;
-
-        if (previousPos.x > 0 && previousPos.y > 0 && inWindow) {
+        if (inWindow) {
             double deltaX = currentPos.x - previousPos.x;
             double deltaY = currentPos.y - previousPos.y;
             boolean rotateX = deltaX != 0;

--- a/src/main/java/net/sknv/engine/MouseInput.java
+++ b/src/main/java/net/sknv/engine/MouseInput.java
@@ -14,6 +14,8 @@ public class MouseInput {
     private boolean inWindow = false;
     private boolean leftClicked = false;
     private boolean rightClicked = false;
+    // Flags when mouse is in GLFW_CURSOR_DISABLED mode.
+    private boolean disabled = true;
 
     public MouseInput() {
         previousPos = new Vector2d(-1, -1);
@@ -80,10 +82,28 @@ public class MouseInput {
         return previousPos;
     }
 
-    public Vector3f getWorldRay(Matrix4f projectionMatrix, Matrix4f viewMatrix) {
+    public void setDisabled() {
+        this.disabled = true;
+    }
+    public void setEnabled() {
+        this.disabled = false;
+    }
+
+    public Vector3f getWorldRay(Window window, Matrix4f projectionMatrix, Matrix4f viewMatrix) {
         //convert from viewport to normalised device space
-        Vector4f ray_clip = new Vector4f((float)(2.0f * getPos().x) / Window.getWidth() - 1.0f,
-                (float)(1f - (2.0f * getPos().y) / Window.getHeight()), -1.0f, 1.0f);
+        double posx;
+        double posy;
+
+        if (this.disabled) {
+            posx = window.getCenter().x;
+            posy = window.getCenter().y;
+        }
+        else {
+            posx = getPos().x;
+            posy = getPos().y;
+        }
+        Vector4f ray_clip = new Vector4f((float)(2.0f * posx) / Window.getWidth() - 1.0f,
+                (float)(1f - (2.0f * posy) / Window.getHeight()), -1.0f, 1.0f);
 
         //convert from normalised device space to eye space
         Matrix4f invertedProjection = new Matrix4f();

--- a/src/main/java/net/sknv/game/Renderer.java
+++ b/src/main/java/net/sknv/game/Renderer.java
@@ -94,7 +94,7 @@ public class Renderer {
         shaderProgram.setUniform("texture_sampler", 0);
 
         //dbz mark -------------------------------------------------------------------------------
-        Vector3f worldRay = mouseInput.getWorldRay(projectionMatrix, viewMatrix);
+        Vector3f worldRay = mouseInput.getWorldRay(window, projectionMatrix, viewMatrix);
         Vector3f cameraPos = camera.getPosition();
 
         //ray casting

--- a/src/main/java/net/sknv/game/Renderer.java
+++ b/src/main/java/net/sknv/game/Renderer.java
@@ -152,7 +152,7 @@ public class Renderer {
         }
 
         if(!clickedItems.isEmpty()) {
-            Float d = cameraPos.distance(clickedItems.get(0).getPos());
+            float d = cameraPos.distance(clickedItems.get(0).getPos());
             for (GameItem item : clickedItems) {
                 if (cameraPos.distance(item.getPos()) <= d) clicked = item;
             }

--- a/src/main/java/net/sknv/game/UltimateKekGame.java
+++ b/src/main/java/net/sknv/game/UltimateKekGame.java
@@ -21,7 +21,7 @@ import static org.lwjgl.glfw.GLFW.*;
 
 public class UltimateKekGame implements IGameLogic {
 
-    private static final float MOUSE_SENSITIVITY = 0.8f;
+    private static final float MOUSE_SENSITIVITY = 0.4f;
     private static final float CAMERA_POS_STEP = 0.05f;
 
     private final Vector3f cameraPosInc;
@@ -178,8 +178,6 @@ public class UltimateKekGame implements IGameLogic {
         if (!menu && glfwGetWindowAttrib(window.getWindowHandle(), GLFW_FOCUSED) == 1) {
             Vector2f rotVec = mouseInput.getDisplVec();
             camera.moveRotation(rotVec.x * MOUSE_SENSITIVITY, rotVec.y * MOUSE_SENSITIVITY, 0);
-
-            glfwSetCursorPos(window.getWindowHandle(), window.getCenter().x, window.getCenter().y);
         }
     }
 
@@ -246,12 +244,11 @@ public class UltimateKekGame implements IGameLogic {
             if (key == GLFW_KEY_P && action == GLFW_PRESS) {
                 if(menu){
                     menu = false;
-                    glfwSetCursorPos(window.getWindowHandle(), window.getCenter().x, window.getCenter().y);
-                    glfwSetInputMode(window.getWindowHandle(), GLFW_CURSOR, GLFW_CURSOR_DISABLED);
+                    glfwSetInputMode(windowHandle, GLFW_CURSOR, GLFW_CURSOR_DISABLED);
                 } else {
                     menu = true;
-                    glfwSetCursorPos(window.getWindowHandle(), window.getCenter().x, window.getCenter().y);
-                    glfwSetInputMode(window.getWindowHandle(), GLFW_CURSOR, GLFW_CURSOR_NORMAL);
+                    glfwSetInputMode(windowHandle, GLFW_CURSOR, GLFW_CURSOR_NORMAL);
+                    glfwSetCursorPos(windowHandle, window.getCenter().x, window.getCenter().y);
                 }
             }
             if (key == GLFW_KEY_ESCAPE && action == GLFW_RELEASE) {

--- a/src/main/java/net/sknv/game/UltimateKekGame.java
+++ b/src/main/java/net/sknv/game/UltimateKekGame.java
@@ -55,9 +55,9 @@ public class UltimateKekGame implements IGameLogic {
     }
 
     @Override
-    public void init(Window window) throws Exception {
+    public void init(Window window, MouseInput mouseInput) throws Exception {
         renderer.init(window);
-        setKeyCallbacks(window);
+        setKeyCallbacks(window, mouseInput);
 
         initLighting();
         initGameItems();
@@ -239,14 +239,16 @@ public class UltimateKekGame implements IGameLogic {
      * For movement keys, where you just want to know if the key IS being pressed,
      * use window.isKeyPressed(key)
      * */
-    private void setKeyCallbacks(Window window) {
+    private void setKeyCallbacks(Window window, MouseInput mouseInput) {
         window.setKeyCallback((windowHandle, key, scancode, action, mods) -> {
             if (key == GLFW_KEY_P && action == GLFW_PRESS) {
                 if(menu){
                     menu = false;
+                    mouseInput.setDisabled();
                     glfwSetInputMode(windowHandle, GLFW_CURSOR, GLFW_CURSOR_DISABLED);
                 } else {
                     menu = true;
+                    mouseInput.setEnabled();
                     glfwSetInputMode(windowHandle, GLFW_CURSOR, GLFW_CURSOR_NORMAL);
                     glfwSetCursorPos(windowHandle, window.getCenter().x, window.getCenter().y);
                 }


### PR DESCRIPTION
Closes #20 

Instead of constantly setting mouse pos to window center, uses GLFW_CURSOR_DISABLED in camera mode and sets raytracing to use window center instead of mouse pos in that mode.