### PR TITLE
Hud FIXED!

### DIFF
--- a/src/main/java/net/sknv/engine/GameEngine.java
+++ b/src/main/java/net/sknv/engine/GameEngine.java
@@ -6,7 +6,7 @@ import net.sknv.game.UltimateKekGame;
 public class GameEngine implements Runnable {
 
     public static final int TARGET_FPS = 144;
-    public static final int TARGET_UPS = 60;
+    public static final int TARGET_UPS = 200;
 
     private final Window window;
     private final Timer timer;

--- a/src/main/java/net/sknv/engine/SkyBox.java
+++ b/src/main/java/net/sknv/engine/SkyBox.java
@@ -36,8 +36,6 @@ public class SkyBox extends GameItemMesh {
         assert ambientLight != null: "You MUST set the Ambient Light with this::setAmbientLight!";
         assert projectionMatrix != null: "You MUST set the Projection Matrix with this::setProjectionMatrix!";
 
-        shaderProgram.bind();
-
         shaderProgram.setUniform("texture_sampler", 0);
         shaderProgram.setUniform("projectionMatrix", projectionMatrix);
 
@@ -48,9 +46,6 @@ public class SkyBox extends GameItemMesh {
         Matrix4f modelViewMatrix = Transformation.getModelViewMatrix(this, vMatrix);
         shaderProgram.setUniform("modelViewMatrix", modelViewMatrix);
         shaderProgram.setUniform("ambientLight", ambientLight);
-
-
-        shaderProgram.unbind();
     }
 
     public void setAmbientLight(Vector3f ambientLight) {

--- a/src/main/java/net/sknv/engine/Window.java
+++ b/src/main/java/net/sknv/engine/Window.java
@@ -78,8 +78,9 @@ public class Window {
         glEnable(GL_DEPTH_TEST);
 
         // cull hidden faces for optimization
-        glEnable(GL_CULL_FACE);
-        glCullFace(GL_BACK);
+        // todo: cull face removes compass. why and how to fix it?
+        // glEnable(GL_CULL_FACE);
+        // glCullFace(GL_BACK);
     }
 
     public void setClearColor(float r, float g, float b, float alpha) {

--- a/src/main/java/net/sknv/engine/entities/GameItemMesh.java
+++ b/src/main/java/net/sknv/engine/entities/GameItemMesh.java
@@ -30,7 +30,6 @@ public class GameItemMesh extends AbstractGameItem {
 
     @Override
     public void render(ShaderProgram shaderProgram, Matrix4f viewMatrix) {
-        shaderProgram.bind();
 
         int drawMode = GL_TRIANGLES;
 
@@ -58,9 +57,6 @@ public class GameItemMesh extends AbstractGameItem {
         //restore state
         glBindVertexArray(0);
         glBindTexture(GL_TEXTURE_2D, 0);
-
-        // reset to default
-        shaderProgram.unbind();
     }
 
     public Mesh getMesh() {

--- a/src/main/java/net/sknv/engine/entities/HudElement.java
+++ b/src/main/java/net/sknv/engine/entities/HudElement.java
@@ -10,15 +10,12 @@ import static org.lwjgl.opengl.GL11.GL_TRIANGLES;
 
 public class HudElement extends GameItemMesh {
 
-    protected transient Mesh mesh;
-
     public HudElement() {
         super();
     }
 
     public HudElement(Mesh mesh) {
-        this();
-        this.mesh = mesh;
+        super(mesh);
     }
 
     @Override

--- a/src/main/java/net/sknv/engine/entities/HudElement.java
+++ b/src/main/java/net/sknv/engine/entities/HudElement.java
@@ -2,11 +2,14 @@ package net.sknv.engine.entities;
 
 import net.sknv.engine.graph.Mesh;
 import net.sknv.engine.graph.ShaderProgram;
+import net.sknv.engine.graph.Texture;
 import net.sknv.engine.graph.Transformation;
 import org.joml.Matrix4f;
-import org.joml.Vector4f;
 
-import static org.lwjgl.opengl.GL11.GL_TRIANGLES;
+import static org.lwjgl.opengl.GL11.*;
+import static org.lwjgl.opengl.GL13.GL_TEXTURE0;
+import static org.lwjgl.opengl.GL13.glActiveTexture;
+import static org.lwjgl.opengl.GL30.glBindVertexArray;
 
 public class HudElement extends GameItemMesh {
 
@@ -20,19 +23,36 @@ public class HudElement extends GameItemMesh {
 
     @Override
     public void render(ShaderProgram shaderProgram, Matrix4f orthoProjMatrix) {
-        shaderProgram.bind();
 
         int drawMode = GL_TRIANGLES;
+
+        Mesh mesh = this.getMesh();
         // Set ortohtaphic and model matrix for this HUD item
         Matrix4f projModelMatrix = Transformation.getOrtoProjModelMatrix(this, orthoProjMatrix);
 
         shaderProgram.setUniform("projModelMatrix", projModelMatrix);
+        shaderProgram.setUniform("colour", mesh.getMaterial().getAmbientColor());
+        shaderProgram.setUniform("hasTexture", mesh.getMaterial().isTextured() ? 1 : 0);
 
+        Texture texture = mesh.getMaterial().getTexture();
+        if (texture != null) {
+            //tell openGL to use first texture bank and bind texture
+            glActiveTexture(GL_TEXTURE0);
+            glBindTexture(GL_TEXTURE_2D, texture.getId());
+            //glPolygonMode(GL_FRONT_AND_BACK, GL_FILL);
+        }
+        else {
+            //for test models
+            //glPolygonMode( GL_FRONT_AND_BACK, GL_LINE );
+        }
 
-        // todo: temp fix, this is spaghet
-        shaderProgram.setUniform("colour", mesh!=null ? mesh.getMaterial().getAmbientColor() : new Vector4f(1, 1, 1, 1));
-        shaderProgram.setUniform("hasTexture", mesh!=null ? (mesh.getMaterial().isTextured() ? 1 : 0) : 0 );
+        //draw mesh
+        glBindVertexArray(mesh.getVaoId());
 
-        shaderProgram.unbind();
+        glDrawElements(drawMode, mesh.getVertexCount(), GL_UNSIGNED_INT, 0);
+
+        //restore state
+        glBindVertexArray(0);
+        glBindTexture(GL_TEXTURE_2D, 0);
     }
 }

--- a/src/main/java/net/sknv/engine/graph/Mesh.java
+++ b/src/main/java/net/sknv/engine/graph/Mesh.java
@@ -329,4 +329,12 @@ public class Mesh {
     }
 
     public ArrayList<Vector3f> getVertices(){return vertices;}
+
+    @Override
+    public String toString() {
+        return "Mesh{" +
+                "modelFile='" + modelFile + '\'' +
+                ", material=" + material +
+                '}';
+    }
 }

--- a/src/main/java/net/sknv/game/Hud.java
+++ b/src/main/java/net/sknv/game/Hud.java
@@ -44,7 +44,7 @@ public class Hud implements IHud {
         compassItem = new HudElement(mesh);
         compassItem.setScale(40.0f);
         // Rotate to transform it to screen coordinates
-        compassItem.setRotationEuclidean(new Vector3f(0f, 0f, 180f));
+        compassItem.setRotationEuclidean(new Vector3f(0f, 0f, (float)Math.PI));
 
         // Create list that holds the items that compose the HUD
         hudElements = new ArrayList<>(List.of(statusTextItem, compassItem));

--- a/src/main/java/net/sknv/game/Hud.java
+++ b/src/main/java/net/sknv/game/Hud.java
@@ -1,11 +1,9 @@
 package net.sknv.game;
 
-import net.sknv.engine.entities.AbstractGameItem;
-import net.sknv.engine.entities.GameItemMesh;
 import net.sknv.engine.IHud;
+import net.sknv.engine.Window;
 import net.sknv.engine.entities.HudElement;
 import net.sknv.engine.entities.TextItem;
-import net.sknv.engine.Window;
 import net.sknv.engine.graph.FontTexture;
 import net.sknv.engine.graph.Material;
 import net.sknv.engine.graph.Mesh;
@@ -49,7 +47,7 @@ public class Hud implements IHud {
         compassItem.setRotationEuclidean(new Vector3f(0f, 0f, 180f));
 
         // Create list that holds the items that compose the HUD
-        hudElements = new ArrayList<HudElement>(List.of(statusTextItem, compassItem));
+        hudElements = new ArrayList<>(List.of(statusTextItem, compassItem));
     }
 
     public void setStatusText(String statusText) {


### PR DESCRIPTION
Closes #51 
Basicamente havia 2 cenas a estragar:
1. O HudElement tinha a sua propria Mesh em vez de usar a Mesh da parent class (GameItemMesh). Fixed on abf620a
2. GL_CULL_FACE was enabled on 799831b7 and this caused the compass to disappear.

### To do:
 Find out how to cull hidden faces without stonkading compass...